### PR TITLE
Move `uploadUrl` config from easy-image package

### DIFF
--- a/src/cloudservices.js
+++ b/src/cloudservices.js
@@ -40,6 +40,7 @@ export default class CloudServices extends Plugin {
 		 * The URL to which the files should be uploaded.
 		 *
 		 * @readonly
+		 * @default 'https://files.cke-cs.com/upload/'
 		 * @member {String} #uploadUrl
 		 */
 

--- a/src/cloudservices.js
+++ b/src/cloudservices.js
@@ -12,6 +12,8 @@ import Token from '@ckeditor/ckeditor-cloudservices-core/src/token/token';
 
 /**
  * Base plugin for Cloud Services. It takes care about the `cloudServices` config options and initializes token provider.
+ *
+ * @extends module:core/plugin~Plugin
  */
 export default class CloudServices extends Plugin {
 	/**
@@ -31,8 +33,19 @@ export default class CloudServices extends Plugin {
 		 * The authentication token URL for CloudServices.
 		 *
 		 * @readonly
-		 * @member {String} #tokenUrl
+		 * @member {String|undefined} #tokenUrl
 		 */
+
+		/**
+		 * The URL to which the files should be uploaded.
+		 *
+		 * @readonly
+		 * @member {String} #uploadUrl
+		 */
+
+		if ( !this.uploadUrl ) {
+			this.uploadUrl = 'https://files.cke-cs.com/upload/';
+		}
 
 		/**
 		 * Other plugins use this token for authorization process. It handles token requesting and refreshing.
@@ -94,4 +107,10 @@ CloudServices.Token = Token;
  *			} );
  *
  * @member {String} module:cloudservices/cloudservices~CloudServicesConfig#tokenUrl
+ */
+
+/**
+ * The URL to which the files should be uploaded.
+ *
+ * @member {String} [module:cloudservices/cloudservices~CloudServicesConfig#uploadUrl='https://files.cke-cs.com/upload/']
  */

--- a/tests/cloudservices.js
+++ b/tests/cloudservices.js
@@ -53,6 +53,33 @@ describe( 'CloudServices', () => {
 				} );
 		} );
 
+		it( 'should expose default uploadUrl if is not provided', () => {
+			return ClassicTestEditor
+				.create( element, {
+					plugins: [ CloudServices ]
+				} )
+				.then( editor => {
+					const cloudServicesPlugin = editor.plugins.get( CloudServices );
+
+					expect( cloudServicesPlugin.uploadUrl ).to.equal( 'https://files.cke-cs.com/upload/' );
+				} );
+		} );
+
+		it( 'should use provided uploadUrl', () => {
+			return ClassicTestEditor
+				.create( element, {
+					plugins: [ CloudServices ],
+					cloudServices: {
+						uploadUrl: 'https://some-upload-url/'
+					}
+				} )
+				.then( editor => {
+					const cloudServicesPlugin = editor.plugins.get( CloudServices );
+
+					expect( cloudServicesPlugin.uploadUrl ).to.equal( 'https://some-upload-url/' );
+				} );
+		} );
+
 		it( 'should provide token if tokenUrl is provided', () => {
 			CloudServices.Token.initialToken = 'initial-token';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Moved `uploadUrl` config from ckeditor5-easy-image package. Closes #6.
